### PR TITLE
Misc fixes and improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["tonic"]
 anyhow = "1.0"
 axum = { version = "0.4.1" }
 axum-extra = "0.1"
-clap = "=3.0.0-beta.5"
+clap = { version = "3.0", features = ["derive", "env"] }
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["tonic"]
 anyhow = "1.0"
 axum = { version = "0.4.1" }
 axum-extra = "0.1"
-clap = { version = "3.0.0-rc.1", features = ["derive", "env"] }
+clap = "=3.0.0-beta.5"
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ metrics = "0.17"
 metrics-exporter-prometheus = "0.7"
 opentelemetry = { version = "0.16.0" }
 opentelemetry-http = { version = "0.5.0" }
+parking_lot = "0.11"
 pin-project-lite = "0.2"
 tokio = { version = "1.14", features = ["rt-multi-thread", "signal", "macros"] }
 tower = { version = "0.4", features = ["util", "timeout"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0"
 axum = { version = "0.4.3" }
 axum-extra = "0.1.1"
 clap = { version = "3.0", features = ["derive", "env"] }
+futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ default = ["tonic"]
 
 [dependencies]
 anyhow = "1.0"
-axum = { version = "0.4.1" }
-axum-extra = "0.1"
+axum = { version = "0.4.3" }
+axum-extra = "0.1.1"
 clap = { version = "3.0", features = ["derive", "env"] }
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14", features = ["full"] }
 metrics = "0.17"
-metrics-exporter-prometheus = "0.6"
+metrics-exporter-prometheus = "0.7"
 opentelemetry = { version = "0.16.0" }
 opentelemetry-http = { version = "0.5.0" }
 pin-project-lite = "0.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,13 +86,14 @@ impl Config {
     }
 }
 
-#[cfg(test)]
-pub(crate) fn test() -> Config {
-    Config {
-        bind_address: "0.0.0.0:8080".parse().unwrap(),
-        metrics_health_port: 8081,
-        http2_only: false,
-        timeout_sec: 30,
-        request_id_header: "x-request-id".to_owned(),
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            bind_address: SocketAddr::from((std::net::Ipv4Addr::UNSPECIFIED, 8080)),
+            metrics_health_port: 8081,
+            http2_only: false,
+            timeout_sec: 30,
+            request_id_header: "x-request-id".to_owned(),
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,7 @@ use std::net::SocketAddr;
 /// ```
 #[derive(Debug, Clone, clap::Parser)]
 #[non_exhaustive]
+#[clap(long_about = "")]
 pub struct Config {
     /// The socket address the server will bind to.
     ///

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,8 +1,8 @@
 //! Kubernetes compatible healh check
 
 use axum::async_trait;
-use std::sync::Arc;
 use parking_lot::Mutex;
+use std::sync::Arc;
 
 /// Used to setup health checks for Kubernetes.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,12 @@ pub use self::server::router_from_tonic;
 /// requires.
 pub type Router<B = BoxBody> = axum::Router<B>;
 
+/// Type alias for [`http::Request`] with [`BoxBody`] as the body type, which this crate requires.
+pub type Request<B = BoxBody> = http::Request<B>;
+
+#[doc(inline)]
+pub use axum::response::Response;
+
 pub mod metrics {
     //! Types and utilities for metrics.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,6 @@
 pub use anyhow;
 pub use axum;
 pub use axum::async_trait;
-use axum::body::BoxBody;
 pub use http;
 #[cfg(feature = "tonic")]
 pub use tonic;
@@ -164,6 +163,8 @@ mod error_handling;
 mod middleware;
 mod request_id;
 mod server;
+
+use axum::body::BoxBody;
 
 pub use self::{config::Config, server::Server};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,7 @@
 pub use anyhow;
 pub use axum;
 pub use axum::async_trait;
+use axum::body::BoxBody;
 pub use http;
 #[cfg(feature = "tonic")]
 pub use tonic;
@@ -168,6 +169,10 @@ pub use self::{config::Config, server::Server};
 
 #[cfg(feature = "tonic")]
 pub use self::server::router_from_tonic;
+
+/// Type alias for [`axum::Router`] with [`BoxBody`] as the request body type, which this crate
+/// requires.
+pub type Router<B = BoxBody> = axum::Router<B>;
 
 pub mod metrics {
     //! Types and utilities for metrics.

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,2 +1,55 @@
+use std::task::{Context, Poll};
+
+use tower::{Layer, Service};
+
 pub(crate) mod metrics;
 pub(crate) mod trace;
+
+/// Combine two layers or services into one.
+///
+/// This differs from `tower::util::Either` in that it doesn't convert the error to `BoxError` but
+/// requires the services to have the same error types.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Either<A, B> {
+    A(A),
+    B(B),
+}
+
+impl<S, A, B> Layer<S> for Either<A, B>
+where
+    A: Layer<S>,
+    B: Layer<S>,
+{
+    type Service = Either<A::Service, B::Service>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        match self {
+            Self::A(layer) => Either::A(layer.layer(inner)),
+            Self::B(layer) => Either::B(layer.layer(inner)),
+        }
+    }
+}
+
+impl<A, B, R> Service<R> for Either<A, B>
+where
+    A: Service<R>,
+    B: Service<R, Response = A::Response, Error = A::Error>,
+{
+    type Response = A::Response;
+    type Error = A::Error;
+    type Future = futures_util::future::Either<A::Future, B::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        match self {
+            Either::A(svc) => svc.poll_ready(cx),
+            Either::B(svc) => svc.poll_ready(cx),
+        }
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        match self {
+            Either::A(svc) => futures_util::future::Either::Left(svc.call(req)),
+            Either::B(svc) => futures_util::future::Either::Right(svc.call(req)),
+        }
+    }
+}

--- a/src/middleware/trace.rs
+++ b/src/middleware/trace.rs
@@ -27,6 +27,7 @@ pub(crate) fn layer() -> TraceLayer<
 
 #[cfg(test)]
 mod tests {
+    use crate::{config::Config, Server};
     use assert_json_diff::assert_json_include;
     use axum::{
         body::Body,
@@ -45,11 +46,9 @@ mod tests {
         EnvFilter,
     };
 
-    use crate::{config, Server};
-
     #[tokio::test]
     async fn correct_fields_on_span_for_http() {
-        let svc = Server::new(config::test())
+        let svc = Server::new(Config::default())
             .with(
                 Router::new()
                     .route("/", get(|| async { StatusCode::OK }))
@@ -150,7 +149,7 @@ mod tests {
 
     #[tokio::test]
     async fn correct_fields_on_span_for_grpc() {
-        let svc = Server::new(config::test())
+        let svc = Server::new(Config::default())
             .with(
                 Router::new()
                     .route(

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,7 +14,6 @@ use axum::{
     AddExtensionLayer, Router,
 };
 use axum_extra::routing::{HasRoutes, RouterExt};
-use clap::Parser;
 use http::{header::HeaderName, Request, StatusCode};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 use std::{
@@ -39,7 +38,7 @@ pub struct Server<F, H> {
 impl Default for Server<DefaultErrorHandler, NoHealthCheckProvided> {
     fn default() -> Self {
         Self {
-            config: Config::parse(),
+            config: Default::default(),
             router: Default::default(),
             error_handler: default_error_handler,
             health_check: NoHealthCheckProvided,

--- a/src/server.rs
+++ b/src/server.rs
@@ -259,7 +259,10 @@ impl<F, H> Server<F, H> {
         self.with(router_from_tonic(service))
     }
 
+    /// Router all requests to the given service.
     ///
+    /// Note that _all_ requests will be sent to the service and therefore the server cannot
+    /// contain other services. If it does you'll get a panic when calling [`Server::serve`].
     pub fn with_service<S, B>(self, service: S) -> Self
     where
         S: Service<Request, Response = Response<B>, Error = Infallible>


### PR DESCRIPTION
These are some misc fixes and improvements I made while porting our internal services to use this crate.

Notable changes:
- Uses clap 3.0
- Added `KillSwitch` which is a health check that can be used to shutdown the whole server if something fatal goes wrong.
- Add type aliases for `Router`, `Request`, and `Response` where the bodies are `BoxBody`, since thats the most common type you'll use with this crate.
- `Config` now has an explicit `Default` impl rather than always relying on argument parsing. It felt weird to parse command line arguments to construct a `Config` during tests.
- Added a "test" config for the server which will disable emitting metrics.
- `HealthCheck` no longer requires `Clone`. You can use `Arc<dyn HealthCheck>` if you have non-clone health check. I don't remember why this was necessary but apparently it was 😅