### PR TITLE
Port metrics middleware to `axum_extra::middleware::from_fn`

### DIFF
--- a/src/middleware/metrics.rs
+++ b/src/middleware/metrics.rs
@@ -1,97 +1,29 @@
-use std::{
-    convert::Infallible,
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-    time::Instant,
-};
+use axum::{extract::MatchedPath, response::IntoResponse};
+use axum_extra::middleware::Next;
+use http::Request;
+use std::time::Instant;
 
-use axum::extract::MatchedPath;
-use http::{Method, Request, Response};
-use pin_project_lite::pin_project;
-use tower::{layer::LayerFn, Service};
+pub(crate) async fn track_metrics<B>(req: Request<B>, next: Next<B>) -> impl IntoResponse {
+    let start = Instant::now();
+    let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
+        matched_path.as_str().to_owned()
+    } else {
+        req.uri().path().to_owned()
+    };
+    let method = req.method().clone();
 
-pub(crate) fn layer<S>() -> LayerFn<fn(S) -> RecordMetrics<S>> {
-    tower::layer::layer_fn(|inner| RecordMetrics { inner })
-}
+    let res = next.run(req).await;
 
-#[derive(Clone)]
-pub(crate) struct RecordMetrics<S> {
-    inner: S,
-}
+    let latency = start.elapsed().as_secs_f64();
+    let status = res.status().as_u16().to_string();
+    let labels = [
+        ("method", method.to_string()),
+        ("path", path),
+        ("status", status),
+    ];
 
-impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for RecordMetrics<S>
-where
-    S: Service<Request<ReqBody>, Response = Response<ResBody>, Error = Infallible>,
-{
-    type Response = S::Response;
-    type Error = Infallible;
-    type Future = RecordMetricsFuture<S::Future>;
+    metrics::increment_counter!("http_requests_total", &labels);
+    metrics::histogram!("http_requests_duration_seconds", latency, &labels);
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
-        let start = Instant::now();
-
-        let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
-            matched_path.as_str().to_owned()
-        } else {
-            req.uri().path().to_owned()
-        };
-
-        let method = req.method().clone();
-
-        RecordMetricsFuture {
-            inner: self.inner.call(req),
-            request_data: Some((method, path)),
-            start,
-        }
-    }
-}
-
-pin_project! {
-    pub(crate) struct RecordMetricsFuture<F> {
-        #[pin]
-        inner: F,
-        request_data: Option<(Method, String)>,
-        start: Instant,
-    }
-}
-
-impl<F, B> Future for RecordMetricsFuture<F>
-where
-    F: Future<Output = Result<Response<B>, Infallible>>,
-{
-    type Output = Result<Response<B>, Infallible>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-
-        match this.inner.poll(cx) {
-            Poll::Ready(Ok(res)) => {
-                let latency = this.start.elapsed().as_secs_f64();
-
-                let status = res.status().as_u16().to_string();
-                let (method, path) = this
-                    .request_data
-                    .take()
-                    .expect("future polled after completion");
-
-                let labels = [
-                    ("method", method.to_string()),
-                    ("path", path),
-                    ("status", status),
-                ];
-
-                metrics::increment_counter!("http_requests_total", &labels);
-                metrics::histogram!("http_requests_duration_seconds", latency, &labels);
-
-                Poll::Ready(Ok(res))
-            }
-            Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
-            Poll::Pending => Poll::Pending,
-        }
-    }
+    res
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use crate::{
     error_handling::{default_error_handler, DefaultErrorHandler},
     health::{AlwaysLiveAndReady, HealthCheck, NoHealthCheckProvided},
-    middleware::{metrics, trace, Either},
+    middleware::{metrics::track_metrics, trace, Either},
     request_id::MakeRequestUuid,
     Config, Request,
 };
@@ -513,7 +513,7 @@ impl<F, H> Server<F, H> {
         let metrics_layer = if self.disable_health_and_metrics {
             Either::A(Identity::new())
         } else {
-            Either::B(metrics::layer())
+            Either::B(axum_extra::middleware::from_fn(track_metrics))
         };
 
         self.router


### PR DESCRIPTION
[`axum_extra::middleware::from_fn`] is way nicer for writing middleware since you don't have to implement `Service` and can use regular async/await syntax. This ports the metrics middleware to use that.

[`axum_extra::middleware::from_fn`]: https://docs.rs/axum-extra/latest/axum_extra/middleware/middleware_fn/fn.from_fn.html