### PR TITLE
Remove `#[derive(clap::Parser)]` from `Config`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ default = ["tonic"]
 anyhow = "1.0"
 axum = { version = "0.4.3" }
 axum-extra = "0.1.1"
-clap = { version = "3.0", features = ["derive", "env"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http = "0.2"
 http-body = "0.4"

--- a/examples/example-axum/src/main.rs
+++ b/examples/example-axum/src/main.rs
@@ -7,7 +7,7 @@ use server_framework::{
 async fn main() {
     init_tracing();
 
-    let config = Config::from_args();
+    let config = Config::default();
 
     let routes = Router::new().route("/", get(root));
 

--- a/examples/example-tonic/src/main.rs
+++ b/examples/example-tonic/src/main.rs
@@ -10,7 +10,7 @@ mod hello_world {
 async fn main() {
     init_tracing();
 
-    let config = Config::from_args();
+    let config = Config::default();
 
     let service = GreeterServer::new(MyGreeter);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,90 +1,33 @@
-use clap::Parser;
 use std::net::SocketAddr;
 
 /// Server configuration.
-///
-/// Supports being parsed from command line arguments (via clap):
-///
-/// ```rust
-/// use server_framework::Config;
-///
-/// let config = Config::from_args();
-/// ```
-///
-/// You can use `#[clap(flatten)]` to combine this with your apps remaining configuration:
-///
-/// ```rust
-/// use server_framework::{Config, Server};
-/// use clap::Parser;
-///
-/// #[derive(clap::Parser)]
-/// struct MyAppConfig {
-///     #[clap(flatten)]
-///     server_config: Config,
-/// }
-///
-/// let config = MyAppConfig::parse();
-///
-/// # async {
-/// Server::new(config.server_config)
-///     .always_live_and_ready()
-///     .serve()
-///     .await
-///     .unwrap();
-/// # };
-/// ```
-#[derive(Debug, Clone, clap::Parser)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
-#[clap(long_about = "")]
 pub struct Config {
     /// The socket address the server will bind to.
     ///
     /// Defaults to `0.0.0.0:8080`.
-    ///
-    /// Can also be set through the `ESF_BIND_ADDRESS` environment variable.
-    #[clap(env = "ESF_BIND_ADDRESS", long, default_value = "0.0.0.0:8080")]
     pub bind_address: SocketAddr,
 
     /// The port the metrics and health server will bind to.
     ///
     /// Defaults to `8081`.
-    ///
-    /// Can also be set through the `ESF_METRICS_HEALTH_PORT` environment variable.
-    #[clap(env = "ESF_METRICS_HEALTH_PORT", long, default_value = "8081")]
     pub metrics_health_port: u16,
 
     /// Whether or not to only accept http2 traffic.
     ///
     /// Defaults to `false`.
-    ///
-    /// Can also be set through the `ESF_HTTP2_ONLY` environment variable.
-    #[clap(env = "ESF_HTTP2_ONLY", long)]
     pub http2_only: bool,
 
     /// The request timeout in seconds.
     ///
     /// Defaults to 30.
-    ///
-    /// Can also be set through the `ESF_TIMEOUT` environment variable.
-    #[clap(env = "ESF_TIMEOUT", long, default_value = "30")]
     pub timeout_sec: u64,
 
     /// The rqeuest id headers.
     ///
     /// Defaults to `x-request-id`.
-    ///
-    /// Can also be set through the `ESF_REQUEST_ID_HEADER` environment variable.
-    #[clap(env = "ESF_REQUEST_ID_HEADER", long, default_value = "x-request-id")]
     pub request_id_header: String,
-}
-
-impl Config {
-    /// Get the config from command line arguments.
-    pub fn from_args() -> Self {
-        let config = Self::parse();
-        tracing::debug!(?config);
-        config
-    }
 }
 
 impl Default for Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@
 //! use server_framework::{Server, Config};
 //! use axum::{Router, routing::get};
 //!
-//! // parse config from command line arguments
-//! let config = Config::from_args();
+//! // use the default config
+//! let config = Config::default();
 //!
 //! // build our application with a few routes
 //! let routes = Router::new()


### PR DESCRIPTION
When integrating this into our internal services we ran into a few oddities that were caused by having `#[derive(clap::Parser)]` on `Config`:

- Docs on the fields becomes help text for CLI arguments. You cannot specify the two separately which means things like default values are repeated in the help text, once from the doc comment and once `#[clap(default_value = "...")]`.
- Not clear whether `Config`'s `Default` implementation should call clap or not. Getting env vars in `Default` is kinda odd but if you don't you have to duplicate the default values in the code.
- Users might wanna customize the prefix used to env vars, that wasn't previously possible.

With this change `Config` is becomes just a regular struct. Users can then build then own CLI arg parsing and convert between their config and our config however they want. Thats a bit less convenient but probably worth it overall.