### PR TITLE
Fix middleware ordering if someone called unknown route

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -520,6 +520,7 @@ impl<F, H> Server<F, H> {
             // these middleware are called for all routes
             .layer(
                 ServiceBuilder::new()
+                    .propagate_request_id(request_id_header.clone())
                     .map_request_body(body::boxed)
                     .layer(HandleErrorLayer::new(self.error_handler))
                     .timeout(Duration::from_secs(self.config.timeout_sec)),
@@ -527,11 +528,10 @@ impl<F, H> Server<F, H> {
             // these middleware are _only_ called for known routes
             .route_layer(
                 ServiceBuilder::new()
-                    .set_request_id(request_id_header.clone(), MakeRequestUuid)
                     .layer(trace::layer())
-                    .propagate_request_id(request_id_header)
                     .layer(metrics_layer),
             )
+            .layer(ServiceBuilder::new().set_request_id(request_id_header, MakeRequestUuid))
     }
 }
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

If someone called a route that didn't exist we would return 500 because a `tower_http::request_id::RequestId` couldn't be found in request extensions. That happened because the error handling middleware (which is invoked on timeouts and other middleware errors) tried to extract it. However the extension would be set inside a [`route_layer`](https://docs.rs/axum/0.4.4/axum/routing/struct.Router.html#method.route_layer) which is only called if there is a matching route. So if someone called route that didn't exist the request id extension would be missing and cause the error.

The solution is to reorder the middleware such that request ids are always set.

I have tested this with our internal services and verified that it does actually work.

### Related Issues

List related issues here
