### PR TITLE
Fix formatting for logged timeout errors

### DIFF
--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -4,41 +4,66 @@ use std::future::{ready, Ready};
 use tower_http::request_id::RequestId;
 
 #[allow(unreachable_pub)]
-pub type DefaultErrorHandler =
-    fn(Method, Uri, Extension<RequestId>, BoxError) -> std::future::Ready<(StatusCode, String)>;
+pub type DefaultErrorHandler = fn(
+    Method,
+    Uri,
+    Extension<RequestId>,
+    Extension<TimeoutSec>,
+    BoxError,
+) -> Ready<(StatusCode, String)>;
 
 pub(crate) fn default_error_handler(
     method: Method,
     uri: Uri,
     Extension(request_id): Extension<RequestId>,
+    Extension(TimeoutSec(timeout_sec)): Extension<TimeoutSec>,
     err: BoxError,
 ) -> Ready<(StatusCode, String)> {
-    if let Ok(request_id) = request_id.header_value().to_str() {
+    let request_id = request_id
+        .header_value()
+        .to_str()
+        .unwrap_or("<mising request id>");
+
+    if err.is::<tower::timeout::error::Elapsed>() {
         tracing::error!(
-            %err,
             %method,
             %uri,
             request_id = %request_id,
-            "error from middleware",
+            timeout_sec = %timeout_sec,
+            "{}",
+            error_display_chain(&*err)
         );
-    } else {
-        tracing::error!(
-            %err,
-            %method,
-            %uri,
-            "error from middleware",
-        );
-    }
 
-    if err.is::<tower::timeout::error::Elapsed>() {
         ready((
             StatusCode::REQUEST_TIMEOUT,
             "Request took too long".to_string(),
         ))
     } else {
+        tracing::error!(
+            err = %error_display_chain(&*err),
+            %method,
+            %uri,
+            request_id = %request_id,
+            "{}",
+            error_display_chain(&*err)
+        );
+
         ready((
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Unhandled internal error: {}", err),
         ))
     }
 }
+
+pub(crate) fn error_display_chain(error: &dyn std::error::Error) -> String {
+    let mut s = error.to_string();
+    if let Some(source) = error.source() {
+        s.push_str(" -> ");
+        s.push_str(&error_display_chain(source));
+    }
+    s
+}
+
+#[derive(Clone, Copy, Debug)]
+#[allow(unreachable_pub)]
+pub struct TimeoutSec(pub(crate) u64);

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,12 +16,7 @@ use axum::{
 use axum_extra::routing::{HasRoutes, RouterExt};
 use http::{header::HeaderName, StatusCode};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
-use std::{
-    convert::Infallible,
-    fmt,
-    net::SocketAddr,
-    time::Duration,
-};
+use std::{convert::Infallible, fmt, net::SocketAddr, time::Duration};
 use tokio::net::TcpListener;
 use tower::{layer::util::Identity, timeout::Timeout, Service, ServiceBuilder};
 use tower_http::ServiceBuilderExt;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error_handling::{default_error_handler, DefaultErrorHandler},
+    error_handling::{default_error_handler, error_display_chain, DefaultErrorHandler, TimeoutSec},
     health::{AlwaysLiveAndReady, HealthCheck, NoHealthCheckProvided},
     middleware::{metrics::track_metrics, trace, Either},
     request_id::MakeRequestUuid,
@@ -511,6 +511,7 @@ impl<F, H> Server<F, H> {
             // these middleware are called for all routes
             .layer(
                 ServiceBuilder::new()
+                    .add_extension(TimeoutSec(self.config.timeout_sec))
                     .propagate_request_id(request_id_header.clone())
                     .map_request_body(body::boxed)
                     .layer(HandleErrorLayer::new(self.error_handler))
@@ -569,7 +570,7 @@ async fn expose_metrics_and_health<H>(
                 "/health/live",
                 get(|Extension(health_check): Extension<H>| async move {
                     if let Err(err) = health_check.is_live().await {
-                        let err = error_display_chain(&err);
+                        let err = error_display_chain(&*err);
                         tracing::error!("readiness heath check failed: {}", err);
                         Err((StatusCode::SERVICE_UNAVAILABLE, err))
                     } else {
@@ -581,7 +582,7 @@ async fn expose_metrics_and_health<H>(
                 "/health/ready",
                 get(|Extension(health_check): Extension<H>| async move {
                     if let Err(err) = health_check.is_ready().await {
-                        let err = error_display_chain(&err);
+                        let err = error_display_chain(&*err);
                         tracing::error!("liveness heath check failed: {}", err);
                         Err((StatusCode::SERVICE_UNAVAILABLE, err))
                     } else {
@@ -654,13 +655,4 @@ where
         .map_response_body(body::boxed)
         .service(service);
     Router::new().route(&format!("/{}/*rest", S::NAME), svc)
-}
-
-fn error_display_chain(error: &anyhow::Error) -> String {
-    let mut s = error.to_string();
-    for source in error.chain() {
-        s.push_str(" -> ");
-        let _ = write!(s, "{}", source);
-    }
-    s
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,7 +18,7 @@ use http::{header::HeaderName, StatusCode};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 use std::{
     convert::Infallible,
-    fmt::{self, Write},
+    fmt,
     net::SocketAddr,
     time::Duration,
 };


### PR DESCRIPTION
If we hit a timeout the logged error should just be `"error from middleware"`. That made things harder to find in sentry.

This changes that by explicitly formatting each kind of middleware error. Its still the application's responsibility to report domain specific errors.