### PR TITLE
Add a way to register metrics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ mod server;
 
 use axum::body::BoxBody;
 
-pub use self::{config::Config, server::MetricRegistrer, server::Server};
+pub use self::{config::Config, server::Server};
 
 #[cfg(feature = "tonic")]
 pub use self::server::router_from_tonic;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ mod server;
 
 use axum::body::BoxBody;
 
-pub use self::{config::Config, server::Server};
+pub use self::{config::Config, server::MetricRegistrer, server::Server};
 
 #[cfg(feature = "tonic")]
 pub use self::server::router_from_tonic;

--- a/src/server.rs
+++ b/src/server.rs
@@ -429,7 +429,9 @@ impl<F, H> Server<F, H> {
         self
     }
 
-    /// Set metric registrer to be called after the metric recorder have been initialized.
+    /// A callback that will be called after the metric recorder is initialized
+    ///
+    /// This can be use to register metrics
     pub fn metric_setup_callback(mut self, callback: Callback) -> Self {
         self.metric_setup_callback = Some(callback);
         self

--- a/src/server.rs
+++ b/src/server.rs
@@ -432,9 +432,9 @@ impl<F, H> Server<F, H> {
     /// A callback that will be called after the metric recorder is initialized
     ///
     /// This can be use to register metrics
-    pub fn metric_setup_callback<F>(mut self, callback: F) -> Self
+    pub fn metric_setup_callback<C>(mut self, callback: C) -> Self
     where
-        F: FnOnce() + Send + 'static,
+        C: FnOnce() + Send + 'static,
     {
         self.metric_setup_callback = Some(Box::new(callback));
         self

--- a/src/server.rs
+++ b/src/server.rs
@@ -549,7 +549,7 @@ type Callback = Box<dyn FnOnce() + Send>;
 async fn expose_metrics_and_health<H>(
     metrics_health_port: u16,
     metric_buckets: Option<Vec<(Matcher, Vec<f64>)>>,
-    metric_setups_callback: Option<Callback>,
+    metric_setup_callback: Option<Callback>,
     health_check: H,
     graceful_shutdown: bool,
 ) where
@@ -574,7 +574,7 @@ async fn expose_metrics_and_health<H>(
 
     ::metrics::set_boxed_recorder(Box::new(recorder)).expect("failed to set metrics recorder");
 
-    if let Some(cb) = metric_setups_callback {
+    if let Some(cb) = metric_setup_callback {
         cb();
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -432,8 +432,11 @@ impl<F, H> Server<F, H> {
     /// A callback that will be called after the metric recorder is initialized
     ///
     /// This can be use to register metrics
-    pub fn metric_setup_callback(mut self, callback: Callback) -> Self {
-        self.metric_setup_callback = Some(callback);
+    pub fn metric_setup_callback<F>(mut self, callback: F) -> Self
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.metric_setup_callback = Some(Box::new(callback));
         self
     }
 


### PR DESCRIPTION
This adds a way of registering metrics after the metrics-recorder have been initialized.

It is [good practice](https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics) to pre-register/initialize metrics when using prometheus, to specify descriptions, but more importantly that `rate` queries can behave in an [unexpected way](https://www.section.io/blog/beware-prometheus-counters-that-do-not-begin-at-zero/) if not initializing counters (that histograms and summaries are built on).


