### PR TITLE
Downgrade tracing level for timeout err

### DIFF
--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -25,7 +25,7 @@ pub(crate) fn default_error_handler(
         .unwrap_or("<mising request id>");
 
     if err.is::<tower::timeout::error::Elapsed>() {
-        tracing::error!(
+        tracing::warn!(
             %method,
             %uri,
             request_id = %request_id,


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Timing out is mostly not an extra-ordinary event, so it's more suitable to emit it with the `warn` level.
These changes downgrades the level from `error` to `warn`

### Related Issues

List related issues here
