### PR TITLE
Fix grpc timeout responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,4 +60,4 @@ serde_json = "1.0"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 
 [workspace]
-members = ["examples/*"]
+members = ["examples/*", "tests/*"]

--- a/examples/example-tonic/Cargo.toml
+++ b/examples/example-tonic/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-prost = "0.9"
+prost = "0.10"
 server-framework = { path = "../../" }
 tokio = { version = "1.14", features = ["full"] }
-tonic = "0.6"
+tonic = "0.7"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]
-tonic-build = "0.6"
+tonic-build = "0.7"

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "integration_test"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+prost = "0.10"
+server-framework = { path = "../../" }
+tokio = { version = "1.14", features = ["full"] }
+tonic = "0.7"
+reqwest = "0.11.10"
+
+[build-dependencies]
+tonic-build = "0.7"

--- a/tests/integration_tests/build.rs
+++ b/tests/integration_tests/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::compile_protos("proto/helloworld.proto")?;
+    Ok(())
+}

--- a/tests/integration_tests/proto/helloworld.proto
+++ b/tests/integration_tests/proto/helloworld.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package helloworld;
+
+service Greeter {
+    rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+message HelloRequest {
+   string name = 1;
+}
+
+message HelloReply {
+    string message = 1;
+}

--- a/tests/integration_tests/src/lib.rs
+++ b/tests/integration_tests/src/lib.rs
@@ -1,0 +1,5 @@
+mod hello_world {
+    tonic::include_proto!("helloworld");
+}
+
+mod timeout;

--- a/tests/integration_tests/src/timeout.rs
+++ b/tests/integration_tests/src/timeout.rs
@@ -1,0 +1,107 @@
+use crate::hello_world::{
+    greeter_client::GreeterClient,
+    greeter_server::{Greeter, GreeterServer},
+    HelloReply, HelloRequest,
+};
+use server_framework::{axum::routing::get, Config, Router, Server};
+use tonic::{transport::Channel, Status};
+
+#[derive(Clone)]
+pub struct MyGreeter;
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: tonic::Request<HelloRequest>,
+    ) -> Result<tonic::Response<HelloReply>, tonic::Status> {
+        let reply = crate::hello_world::HelloReply {
+            message: format!("Hello {}!", request.into_inner().name),
+        };
+
+        // Sleep to trigger the server side timeout
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+        Ok(tonic::Response::new(reply))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn grpc_timeout_response() {
+    let mut config = Config::default();
+    config.timeout_sec = 1;
+    config.bind_address = "0.0.0.0:8080".parse().unwrap();
+
+    let bind_address = config.bind_address;
+
+    let task = tokio::spawn(async {
+        Server::new(config)
+            .with_tonic(GreeterServer::new(MyGreeter))
+            .always_live_and_ready()
+            .serve()
+            .await
+            .expect("server failed to start");
+    });
+
+    let channel = Channel::builder(format!("http://{}", bind_address).parse().unwrap())
+        .connect()
+        .await
+        .unwrap();
+
+    let mut client = GreeterClient::new(channel);
+
+    let request = tonic::Request::new(HelloRequest {
+        name: "test".into(),
+    });
+
+    // Will timeout
+    let status = client.say_hello(request).await.unwrap_err();
+
+    let expected = Status::deadline_exceeded("request timed out");
+
+    assert_eq!(status.code(), expected.code());
+    assert_eq!(status.message(), expected.message());
+
+    task.abort();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_timeout_response() {
+    let mut config = Config::default();
+    config.timeout_sec = 1;
+
+    config.bind_address = "0.0.0.0:8082".parse().unwrap();
+
+    let bind_address = config.bind_address;
+
+    let routes = Router::new().route(
+        "/",
+        get(|| async {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            "Hello, World!"
+        }),
+    );
+
+    let task = tokio::spawn(async {
+        Server::new(config)
+            .with(routes)
+            .always_live_and_ready()
+            .serve()
+            .await
+            .expect("server failed to start");
+    });
+
+    // Will timeout
+    let response = reqwest::get(format!("http://{}", bind_address))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), reqwest::StatusCode::REQUEST_TIMEOUT);
+
+    assert_eq!(
+        response.text().await.unwrap(),
+        "request timed out".to_string()
+    );
+
+    task.abort();
+}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
The default error handler would send "plain" HTTP traffic as a response regardless if the protocol used was grpc or not. Since the caller expects grpc back from the server the client would fail to parse the response with errors like "Invalid compression flag" since the response didn't match the grpc protocol specification. This PR changes the error handler to take grpc into account and adds some integration tests to prevent future regression.

